### PR TITLE
Fix java.nio.*Buffer issues

### DIFF
--- a/src/main/java/org/javafxports/jfxmobile/plugin/RetrobufferExec.java
+++ b/src/main/java/org/javafxports/jfxmobile/plugin/RetrobufferExec.java
@@ -1,0 +1,103 @@
+package org.javafxports.jfxmobile.plugin;
+
+import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+public class RetrobufferExec {
+
+    private static final int COMMANDLINE_LENGTH_LIMIT = 3496;
+
+    private FileCollection retrobufferClasspath;
+    private File inputDir;
+    private File outputDir;
+    private List<String> jvmArgs;
+
+    private final Project project;
+
+    public RetrobufferExec(Project project) {
+        this.project = project;
+    }
+
+    public FileCollection getRetrobufferClasspath() {
+        return retrobufferClasspath;
+    }
+
+    public void setRetrobufferClasspath(FileCollection retrobufferClasspath) {
+        this.retrobufferClasspath = retrobufferClasspath;
+    }
+
+    public File getInputDir() {
+        return inputDir;
+    }
+
+    public void setInputDir(File inputDir) {
+        this.inputDir = inputDir;
+    }
+
+    public File getOutputDir() {
+        return outputDir;
+    }
+
+    public void setOutputDir(File outputDir) {
+        this.outputDir = outputDir;
+    }
+
+    public List<String> getJvmArgs() {
+        return jvmArgs;
+    }
+
+    public void setJvmArgs(List<String> jvmArgs) {
+        this.jvmArgs = jvmArgs;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public void exec() {
+        project.javaexec(exec -> {
+            exec.setClasspath(project.getBuildscript().getConfigurations().getByName("classpath"));
+
+            String path = retrobufferClasspath.getAsPath();
+
+            exec.setMain("org.javafxports.retrobuffer.Main");
+            exec.setJvmArgs(Arrays.asList(
+                    "-Dretrobuffer.inputDir=" + inputDir,
+                    "-Dretrobuffer.outputDir=" + outputDir,
+                    "-Dretrobuffer.classpath=" + path
+            ));
+
+            if (classpathLengthGreaterThanLimit(path)) {
+                try {
+                    File classpathFile = File.createTempFile("inc-", ".path");
+                    try (BufferedWriter writer = Files.newBufferedWriter(classpathFile.toPath(), StandardCharsets.UTF_8)) {
+                        for (File item : this.retrobufferClasspath) {
+                            writer.write(item.toString() + "\n");
+                        }
+                    }
+                    classpathFile.deleteOnExit();
+                    exec.getJvmArgs().add("-Dretrobuffer.classpathFile=" + classpathFile.getAbsolutePath());
+                } catch (IOException e) {
+                }
+            } else {
+                exec.getJvmArgs().add("-Dretrobuffer.classpath=" + path);
+            }
+
+            for (String arg : jvmArgs) {
+                exec.getJvmArgs().add(arg);
+            }
+        });
+    }
+
+    private static boolean classpathLengthGreaterThanLimit(String path) {
+        return path.length() > COMMANDLINE_LENGTH_LIMIT;
+    }
+}

--- a/src/main/java/org/javafxports/jfxmobile/plugin/RetrobufferExec.java
+++ b/src/main/java/org/javafxports/jfxmobile/plugin/RetrobufferExec.java
@@ -1,3 +1,34 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.javafxports.jfxmobile.plugin;
 
 import org.gradle.api.Project;

--- a/src/main/java/org/javafxports/jfxmobile/plugin/android/task/Retrobuffer.java
+++ b/src/main/java/org/javafxports/jfxmobile/plugin/android/task/Retrobuffer.java
@@ -1,3 +1,34 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.javafxports.jfxmobile.plugin.android.task;
 
 import org.gradle.api.DefaultTask;

--- a/src/main/java/org/javafxports/jfxmobile/plugin/android/task/Retrobuffer.java
+++ b/src/main/java/org/javafxports/jfxmobile/plugin/android/task/Retrobuffer.java
@@ -1,0 +1,67 @@
+package org.javafxports.jfxmobile.plugin.android.task;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+import org.javafxports.jfxmobile.plugin.RetrobufferExec;
+
+import java.io.File;
+import java.util.Collections;
+
+public class Retrobuffer extends DefaultTask {
+
+    @InputFiles
+    @Optional
+    private FileCollection classpath;
+
+    @InputDirectory
+    private File retrobufferInput;
+
+    @OutputDirectory
+    private File retrobufferOutput;
+
+    public FileCollection getClasspath() {
+        return classpath;
+    }
+
+    public void setClasspath(FileCollection classpath) {
+        this.classpath = classpath;
+    }
+
+    public File getRetrobufferInput() {
+        return retrobufferInput;
+    }
+
+    public void setRetrobufferInput(File retrobufferInput) {
+        this.retrobufferInput = retrobufferInput;
+    }
+
+    public File getRetrobufferOutput() {
+        return retrobufferOutput;
+    }
+
+    public void setRetrobufferOutput(File retrobufferOutput) {
+        this.retrobufferOutput = retrobufferOutput;
+    }
+
+    @TaskAction
+    public void action() {
+        RetrobufferExec exec = new RetrobufferExec(getProject());
+        exec.setInputDir(getRetrobufferInput());
+        exec.setOutputDir(getRetrobufferOutput());
+
+        if (getClasspath() == null || getClasspath().isEmpty()) {
+            exec.setRetrobufferClasspath(getProject().files(getRetrobufferInput()));
+        } else {
+            exec.setRetrobufferClasspath(getProject().files(getRetrobufferInput(), getClasspath()));
+        }
+
+        exec.setJvmArgs(Collections.emptyList());
+        exec.exec();
+    }
+
+}

--- a/src/main/java/org/javafxports/retrobuffer/ClassAnalyzer.java
+++ b/src/main/java/org/javafxports/retrobuffer/ClassAnalyzer.java
@@ -1,3 +1,34 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.javafxports.retrobuffer;
 
 import org.objectweb.asm.ClassReader;

--- a/src/main/java/org/javafxports/retrobuffer/ClassAnalyzer.java
+++ b/src/main/java/org/javafxports/retrobuffer/ClassAnalyzer.java
@@ -1,0 +1,36 @@
+package org.javafxports.retrobuffer;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Type;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+
+public class ClassAnalyzer {
+
+    private Map<Type, ClassInfo> classes = new HashMap<>();
+
+    public void analyze(byte[] bytecode) {
+        ClassReader cr = new ClassReader(bytecode);
+        ClassInfo c = new ClassInfo(cr);
+
+        classes.put(c.getType(), c);
+    }
+
+    public List<ClassInfo> getInterfaces() {
+        return classes.values()
+                .stream()
+                .filter(ClassInfo::isInterface)
+                .collect(toList());
+    }
+
+    public List<ClassInfo> getClasses() {
+        return classes.values()
+                .stream()
+                .filter(ClassInfo::isClass)
+                .collect(toList());
+    }
+}

--- a/src/main/java/org/javafxports/retrobuffer/ClassInfo.java
+++ b/src/main/java/org/javafxports/retrobuffer/ClassInfo.java
@@ -1,3 +1,34 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.javafxports.retrobuffer;
 
 import org.objectweb.asm.ClassReader;

--- a/src/main/java/org/javafxports/retrobuffer/ClassInfo.java
+++ b/src/main/java/org/javafxports/retrobuffer/ClassInfo.java
@@ -1,0 +1,33 @@
+package org.javafxports.retrobuffer;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Type;
+
+public class ClassInfo {
+
+    private ClassReader reader;
+    private final int access;
+    private final Type type;
+
+    public ClassInfo(ClassReader cr) {
+        this.reader = cr;
+        this.access = cr.getAccess();
+        this.type = Type.getObjectType(cr.getClassName());
+    }
+
+    public ClassReader getReader() {
+        return reader;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public boolean isClass() {
+        return !isInterface();
+    }
+
+    public boolean isInterface() {
+        return Util.isInterface(access);
+    }
+}

--- a/src/main/java/org/javafxports/retrobuffer/ClasspathVisitor.java
+++ b/src/main/java/org/javafxports/retrobuffer/ClasspathVisitor.java
@@ -1,0 +1,44 @@
+package org.javafxports.retrobuffer;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public abstract class ClasspathVisitor extends SimpleFileVisitor<Path> {
+
+    private Path baseDir;
+
+    @Override
+    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+        if (baseDir == null) {
+            baseDir = dir;
+        }
+        return super.preVisitDirectory(dir, attrs);
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        Path relativePath = baseDir.relativize(file);
+        byte[] content = Files.readAllBytes(file);
+
+        if (isJavaClass(relativePath)) {
+            visitClass(content);
+        } else {
+            visitResource(relativePath, content);
+        }
+
+        return FileVisitResult.CONTINUE;
+    }
+
+    protected abstract void visitClass(byte[] bytecode) throws IOException;
+
+    protected abstract void visitResource(Path relativePath, byte[] bytecode) throws IOException;
+
+    private static boolean isJavaClass(Path file) {
+        String fileName = file.getFileName().toString();
+        return fileName.endsWith(".class") && !fileName.equals("module-info.class");
+    }
+}

--- a/src/main/java/org/javafxports/retrobuffer/ClasspathVisitor.java
+++ b/src/main/java/org/javafxports/retrobuffer/ClasspathVisitor.java
@@ -1,3 +1,34 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.javafxports.retrobuffer;
 
 import java.io.IOException;

--- a/src/main/java/org/javafxports/retrobuffer/Main.java
+++ b/src/main/java/org/javafxports/retrobuffer/Main.java
@@ -1,3 +1,34 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.javafxports.retrobuffer;
 
 import java.util.logging.Level;

--- a/src/main/java/org/javafxports/retrobuffer/Main.java
+++ b/src/main/java/org/javafxports/retrobuffer/Main.java
@@ -1,0 +1,21 @@
+package org.javafxports.retrobuffer;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class Main {
+
+    private static final Logger LOG = Logger.getLogger(Main.class.getName());
+
+    public static void main(String[] args) {
+        SystemPropertiesConfig config = new SystemPropertiesConfig(System.getProperties());
+
+        try {
+            Retrobuffer.run(config);
+        } catch (Throwable t) {
+            LOG.log(Level.SEVERE, "Failed to run Retrobuffer", t);
+            System.exit(1);
+        }
+
+    }
+}

--- a/src/main/java/org/javafxports/retrobuffer/NonDelegatingClassLoader.java
+++ b/src/main/java/org/javafxports/retrobuffer/NonDelegatingClassLoader.java
@@ -1,3 +1,34 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.javafxports.retrobuffer;
 
 import java.net.URL;

--- a/src/main/java/org/javafxports/retrobuffer/NonDelegatingClassLoader.java
+++ b/src/main/java/org/javafxports/retrobuffer/NonDelegatingClassLoader.java
@@ -1,0 +1,27 @@
+package org.javafxports.retrobuffer;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class NonDelegatingClassLoader extends URLClassLoader {
+
+    public NonDelegatingClassLoader(URL[] urls) {
+        super(urls);
+    }
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        if (name.startsWith("java.")) { // the java.* classes can only be loaded by the bootstrap class loader
+            return super.loadClass(name);
+        }
+        Class<?> c = findLoadedClass(name);
+        if (c != null) {
+            return c;
+        }
+        try {
+            return findClass(name);
+        } catch (ClassNotFoundException e) {
+            return super.loadClass(name);
+        }
+    }
+}

--- a/src/main/java/org/javafxports/retrobuffer/OutputDirectory.java
+++ b/src/main/java/org/javafxports/retrobuffer/OutputDirectory.java
@@ -1,3 +1,34 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.javafxports.retrobuffer;
 
 import org.objectweb.asm.ClassReader;

--- a/src/main/java/org/javafxports/retrobuffer/OutputDirectory.java
+++ b/src/main/java/org/javafxports/retrobuffer/OutputDirectory.java
@@ -1,0 +1,31 @@
+package org.javafxports.retrobuffer;
+
+import org.objectweb.asm.ClassReader;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class OutputDirectory {
+
+    private final Path outputDir;
+
+    public OutputDirectory(Path outputDir) {
+        this.outputDir = outputDir;
+    }
+
+    public void writeClass(byte[] bytecode) throws IOException {
+        if (bytecode == null) {
+            return;
+        }
+        ClassReader cr = new ClassReader(bytecode);
+        Path relativePath = outputDir.getFileSystem().getPath(cr.getClassName() + ".class");
+        writeFile(relativePath, bytecode);
+    }
+
+    public void writeFile(Path relativePath, byte[] content) throws IOException {
+        Path outputFile = outputDir.resolve(relativePath);
+        Files.createDirectories(outputFile.getParent());
+        Files.write(outputFile, content);
+    }
+}

--- a/src/main/java/org/javafxports/retrobuffer/Retrobuffer.java
+++ b/src/main/java/org/javafxports/retrobuffer/Retrobuffer.java
@@ -1,3 +1,34 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.javafxports.retrobuffer;
 
 import java.io.IOException;

--- a/src/main/java/org/javafxports/retrobuffer/Retrobuffer.java
+++ b/src/main/java/org/javafxports/retrobuffer/Retrobuffer.java
@@ -1,0 +1,67 @@
+package org.javafxports.retrobuffer;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Retrobuffer {
+
+    public static void run(SystemPropertiesConfig config) throws IOException {
+        Path inputDir = config.getInputDir();
+        Path outputDir = config.getOutputDir();
+        List<Path> classpath = config.getClasspath();
+
+        Thread.currentThread().setContextClassLoader(new NonDelegatingClassLoader(asUrls(classpath)));
+
+        ClassAnalyzer analyzer = new ClassAnalyzer();
+        Transformer transformer = new Transformer();
+
+        OutputDirectory outputDirectory = new OutputDirectory(outputDir);
+        Files.walkFileTree(inputDir, new ClasspathVisitor() {
+            @Override
+            protected void visitClass(byte[] bytecode) {
+                analyzer.analyze(bytecode);
+            }
+
+            @Override
+            protected void visitResource(Path relativePath, byte[] content) throws IOException {
+                outputDirectory.writeFile(relativePath, content);
+            }
+        });
+
+        List<ClassInfo> interfaces = analyzer.getInterfaces();
+        List<ClassInfo> classes = analyzer.getClasses();
+
+        List<byte[]> transformed = new ArrayList<>();
+        for (ClassInfo c : interfaces) {
+            transformed.add(transformer.backport(c.getReader()));
+        }
+        for (ClassInfo c : classes) {
+            transformed.add(transformer.backport(c.getReader()));
+        }
+
+        for (byte[] bytecode : transformed) {
+            outputDirectory.writeClass(bytecode);
+        }
+    }
+
+    private static URL[] asUrls(List<Path> classpath) {
+        return classpath.stream()
+                .map(Path::toUri)
+                .map(Retrobuffer::uriToUrl)
+                .toArray(URL[]::new);
+    }
+
+    private static URL uriToUrl(URI uri) {
+        try {
+            return uri.toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/org/javafxports/retrobuffer/SystemPropertiesConfig.java
+++ b/src/main/java/org/javafxports/retrobuffer/SystemPropertiesConfig.java
@@ -1,0 +1,72 @@
+package org.javafxports.retrobuffer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class SystemPropertiesConfig {
+
+    private static final String PREFIX = "retrobuffer.";
+    private static final String CLASSPATH = PREFIX + "classpath";
+    private static final String CLASSPATH_FILE = CLASSPATH + "File";
+    private static final String INPUT_DIR = PREFIX + "inputDir";
+    private static final String OUTPUT_DIR = PREFIX + "outputDir";
+
+    private final Properties p;
+
+    public SystemPropertiesConfig(Properties properties) {
+        this.p = properties;
+    }
+
+    public Path getInputDir() {
+        String inputDir = p.getProperty(INPUT_DIR);
+        if (inputDir != null) {
+            return Paths.get(inputDir);
+        }
+        throw new IllegalArgumentException("Missing required property: " + INPUT_DIR);
+    }
+
+    public Path getOutputDir() {
+        String outputDir = p.getProperty(OUTPUT_DIR);
+        if (outputDir != null) {
+            return Paths.get(outputDir);
+        }
+        return getInputDir();
+    }
+
+    public List<Path> getClasspath() {
+        String classpath = p.getProperty(CLASSPATH);
+        if (classpath != null) {
+            return parsePathList(classpath);
+        }
+        String classpathFile = p.getProperty(CLASSPATH_FILE);
+        if (classpathFile != null) {
+            return readPathList(Paths.get(classpathFile));
+        }
+        throw new IllegalArgumentException("Missing required property: " + CLASSPATH);
+    }
+
+    private static List<Path> parsePathList(String paths) {
+        return Stream.of(paths.split(File.pathSeparator))
+                .filter(path -> !path.isEmpty())
+                .map(Paths::get)
+                .collect(Collectors.toList());
+    }
+
+    private static List<Path> readPathList(Path file) {
+        try {
+            return Files.readAllLines(file).stream()
+                    .filter(line -> !line.isEmpty())
+                    .map(Paths::get)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read " + file, e);
+        }
+    }
+}

--- a/src/main/java/org/javafxports/retrobuffer/SystemPropertiesConfig.java
+++ b/src/main/java/org/javafxports/retrobuffer/SystemPropertiesConfig.java
@@ -1,3 +1,34 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.javafxports.retrobuffer;
 
 import java.io.File;

--- a/src/main/java/org/javafxports/retrobuffer/Transformer.java
+++ b/src/main/java/org/javafxports/retrobuffer/Transformer.java
@@ -1,0 +1,39 @@
+package org.javafxports.retrobuffer;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+
+import java.util.function.Consumer;
+
+public class Transformer {
+
+    public byte[] backport(ClassReader reader) {
+        return transform(reader, (next) -> {
+            next = new UpdateBufferMethods(next);
+            return next;
+        });
+    }
+
+    private byte[] transform(ClassReader reader, ClassVisitorChain chain) {
+        return transform(reader.getClassName(), cv -> reader.accept(cv, 0), chain);
+    }
+
+    private byte[] transform(String className, Consumer<ClassVisitor> reader, ClassVisitorChain chain) {
+        try {
+            ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+            ClassVisitor next = writer;
+
+            next = chain.wrap(next);
+
+            reader.accept(next);
+            return writer.toByteArray();
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to backport class: " + className, t);
+        }
+    }
+
+    private interface ClassVisitorChain {
+        ClassVisitor wrap(ClassVisitor next);
+    }
+}

--- a/src/main/java/org/javafxports/retrobuffer/Transformer.java
+++ b/src/main/java/org/javafxports/retrobuffer/Transformer.java
@@ -1,3 +1,34 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.javafxports.retrobuffer;
 
 import org.objectweb.asm.ClassReader;

--- a/src/main/java/org/javafxports/retrobuffer/UpdateBufferMethods.java
+++ b/src/main/java/org/javafxports/retrobuffer/UpdateBufferMethods.java
@@ -1,0 +1,110 @@
+package org.javafxports.retrobuffer;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public class UpdateBufferMethods extends ClassVisitor {
+
+    private static final Logger LOG = Logger.getLogger(UpdateBufferMethods.class.getName());
+
+    private String methodOwner;
+
+    private static final List<String> owners = Arrays.asList("java/nio/ByteBuffer",
+            "java/nio/CharBuffer", "java/nio/DoubleBuffer", "java/nio/FloatBuffer",
+            "java/nio/IntBuffer", "java/nio/LongBuffer", "java/nio/ShortBuffer",
+            "java/nio/MappedByteBuffer");
+
+    private static final List<String> names = Arrays.asList("clear", "flip",
+            "limit", "mark", "position", "reset", "rewind");
+
+    private static final List<MethodInstruction> methodInstructions = owners.stream()
+            .map(owner -> names.stream()
+                    .map(name -> new MethodInstruction(owner, name))
+                    .collect(Collectors.toList()))
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+
+    public UpdateBufferMethods(ClassVisitor next) {
+        super(Opcodes.ASM5, next);
+    }
+
+    @Override
+    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        super.visit(version, access, name, signature, superName, interfaces);
+
+        this.methodOwner = name;
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String methodName, String desc, String signature, String[] exceptions) {
+        MethodVisitor next = super.visitMethod(access, methodName, desc, signature, exceptions);
+        return new MethodVisitor(Opcodes.ASM5, next) {
+            @Override
+            public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+                if (opcode == Opcodes.INVOKEVIRTUAL) {
+                    MethodInstruction lookup = new MethodInstruction(owner, name, desc);
+                    if (methodInstructions.contains(lookup)) {
+                        LOG.log(Level.INFO, "Transforming java.nio.Buffer invocation in " + methodOwner + "." + methodName + ": " + owner + "." + name + " " + desc);
+                        super.visitMethodInsn(opcode, "java/nio/Buffer", name, desc.substring(0, desc.indexOf("L") + 1) + "java/nio/Buffer;", itf);
+                    } else {
+                        super.visitMethodInsn(opcode, owner, name, desc, itf);
+                    }
+                } else {
+                    super.visitMethodInsn(opcode, owner, name, desc, itf);
+                }
+            }
+        };
+    }
+
+    private static final class MethodInstruction {
+
+        private final String owner;
+        private final String name;
+        private final String desc;
+
+        public MethodInstruction(String owner, String name) {
+            this.owner = owner;
+            this.name = name;
+
+            switch (name) {
+                case "limit":
+                case "position":
+                    this.desc = "(I)L" + owner + ";";
+                    break;
+                default:
+                    this.desc = "()L" + owner + ";";
+                    break;
+            }
+        }
+
+        public MethodInstruction(String owner, String name, String desc) {
+            this.owner = owner;
+            this.name = name;
+            this.desc = desc;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            MethodInstruction that = (MethodInstruction) o;
+            return Objects.equals(owner, that.owner) &&
+                    Objects.equals(name, that.name) &&
+                    Objects.equals(desc, that.desc);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(owner, name, desc);
+        }
+    }
+}

--- a/src/main/java/org/javafxports/retrobuffer/UpdateBufferMethods.java
+++ b/src/main/java/org/javafxports/retrobuffer/UpdateBufferMethods.java
@@ -1,3 +1,34 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.javafxports.retrobuffer;
 
 import org.objectweb.asm.ClassVisitor;

--- a/src/main/java/org/javafxports/retrobuffer/Util.java
+++ b/src/main/java/org/javafxports/retrobuffer/Util.java
@@ -1,0 +1,14 @@
+package org.javafxports.retrobuffer;
+
+import static org.objectweb.asm.Opcodes.ACC_INTERFACE;
+
+public class Util {
+
+    public static boolean hasFlag(int subject, int flag) {
+        return (subject & flag) == flag;
+    }
+
+    public static boolean isInterface(int access) {
+        return hasFlag(access, ACC_INTERFACE);
+    }
+}

--- a/src/main/java/org/javafxports/retrobuffer/Util.java
+++ b/src/main/java/org/javafxports/retrobuffer/Util.java
@@ -1,3 +1,34 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.javafxports.retrobuffer;
 
 import static org.objectweb.asm.Opcodes.ACC_INTERFACE;


### PR DESCRIPTION
Fixes #13. The PR adds code that will convert invocations on `java.nio.*Buffer` methods to be called on `java.nio.Buffer` instead for the following methods: `clear()`, `flip()`, `limit(int)`, `mark()`, `position(int)`, `reset()` and `rewind()`.

It basically changes an invokevirtual bytecode invocation from:

> 115: invokevirtual #18                 // Method java/nio/ByteBuffer.clear:()Ljava/nio/ByteBuffer;

to

> 115: invokevirtual #71                 // Method java/nio/Buffer.clear:()Ljava/nio/Buffer;