### PR TITLE
only clear android build output when executing android tasks

### DIFF
--- a/src/main/groovy/org/javafxports/jfxmobile/plugin/JFXMobilePlugin.groovy
+++ b/src/main/groovy/org/javafxports/jfxmobile/plugin/JFXMobilePlugin.groovy
@@ -51,6 +51,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ApplicationPlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.bundling.Jar
@@ -394,6 +395,10 @@ class JFXMobilePlugin implements Plugin<Project> {
     }
 
     private void createAndroidTasks() {
+        Delete cleanAndroidTask = project.tasks.create("cleanAndroid", Delete) {
+            delete project.jfxmobile.android.temporaryDirectory, project.jfxmobile.android.installDirectory
+        }
+
         ValidateManifest validateManifestTask = project.tasks.create("validateManifest", ValidateManifest)
         validateManifestTask.conventionMapping.map("output") { project.file("${project.jfxmobile.android.temporaryDirectory}/AndroidManifest.xml") }
         androidTasks.add(validateManifestTask)
@@ -468,7 +473,7 @@ class JFXMobilePlugin implements Plugin<Project> {
         File componentsJarFile = project.file("${project.jfxmobile.android.multidexOutputDirectory}/componentClasses.jar")
         proguardComponentsTask.outjars(componentsJarFile)
         proguardComponentsTask.printconfiguration("${project.jfxmobile.android.multidexOutputDirectory}/components.flags")
-        proguardComponentsTask.dependsOn manifestKeepListTask, mergeClassesIntoJarTask
+        proguardComponentsTask.dependsOn cleanAndroidTask, manifestKeepListTask, mergeClassesIntoJarTask
         androidTasks.add(proguardComponentsTask)
 
         CreateMainDexList createMainDexListTask = project.tasks.create("createMainDexList", CreateMainDexList)

--- a/src/main/groovy/org/javafxports/jfxmobile/plugin/android/task/ValidateManifest.groovy
+++ b/src/main/groovy/org/javafxports/jfxmobile/plugin/android/task/ValidateManifest.groovy
@@ -36,6 +36,9 @@ import org.gradle.api.GradleException
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
 /**
  * Check if provided AndroidManifest.xml file exists if it is specified. When
  * it's not specified, create a default one.
@@ -55,7 +58,7 @@ class ValidateManifest extends DefaultTask {
                 throw new GradleException("Configured manifest file is invalid: ${project.jfxmobile.android.manifest}")
             }
 
-            java.nio.file.Files.copy(manifestFile.toPath(), getOutput().toPath())
+            Files.copy(manifestFile.toPath(), getOutput().toPath(), StandardCopyOption.REPLACE_EXISTING)
         } else {
             def projectVersion = project.version == 'unspecified' ? '1.0' : project.version
 

--- a/src/main/java/org/javafxports/jfxmobile/plugin/android/AndroidExtension.java
+++ b/src/main/java/org/javafxports/jfxmobile/plugin/android/AndroidExtension.java
@@ -57,8 +57,6 @@ import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
 import java.io.File;
 import java.util.Collections;
 
-import static org.codehaus.groovy.runtime.ResourceGroovyMethods.deleteDir;
-
 public class AndroidExtension {
 
     private final Project project;
@@ -136,13 +134,9 @@ public class AndroidExtension {
         this.taskFactory = new TaskContainerAdaptor(project.getTasks());
 
         installDirectory = new File(project.getBuildDir(), "javafxports/android");
-        deleteDir(installDirectory);
-        installDirectory.mkdirs();
         project.getLogger().info("Android install directory: " + installDirectory);
 
         temporaryDirectory = new File(project.getBuildDir(), "javafxports/tmp/android");
-        deleteDir(temporaryDirectory);
-        temporaryDirectory.mkdirs();
         project.getLogger().info("Android temporary output directory: " + temporaryDirectory);
 
         resourcesDirectory = new File(temporaryDirectory, "resources");


### PR DESCRIPTION
This is a fix for issue #15. It only deletes the android build output when executing the proguard task (shrinkMultiDexComponents).