### PR TITLE
Better explanation of why RetroBuffer fails

### DIFF
--- a/src/main/groovy/org/javafxports/jfxmobile/plugin/JFXMobilePlugin.groovy
+++ b/src/main/groovy/org/javafxports/jfxmobile/plugin/JFXMobilePlugin.groovy
@@ -312,10 +312,6 @@ class JFXMobilePlugin implements Plugin<Project> {
 
             // only configure android when one of the android tasks will be run
             if (androidTasks.find { project.gradle.taskGraph.hasTask(it) } != null) {
-                if (JavaVersion.current().getMajorVersion() != JavaVersion.VERSION_1_8.getMajorVersion()) {
-                    project.logger.warn("Warning: using Gluon VM with Android requires Java " + JavaVersion.VERSION_1_8.getMajorVersion() + ", but Java " + JavaVersion.current().getMajorVersion() + " was detected.");
-                }
-
                 if (!hasAndroidMavenRepository)  {
                     throw new GradleException("You must install the Android Support Repository. Open the Android SDK Manager and choose the Android Support Repository from the Extras category at the bottom of the list of packages.")
                 }

--- a/src/main/java/org/javafxports/retrobuffer/ClasspathVisitor.java
+++ b/src/main/java/org/javafxports/retrobuffer/ClasspathVisitor.java
@@ -56,7 +56,7 @@ public abstract class ClasspathVisitor extends SimpleFileVisitor<Path> {
         byte[] content = Files.readAllBytes(file);
 
         if (isJavaClass(relativePath)) {
-            visitClass(content);
+            visitClass(relativePath, content);
         } else {
             visitResource(relativePath, content);
         }
@@ -64,7 +64,7 @@ public abstract class ClasspathVisitor extends SimpleFileVisitor<Path> {
         return FileVisitResult.CONTINUE;
     }
 
-    protected abstract void visitClass(byte[] bytecode) throws IOException;
+    protected abstract void visitClass(Path relativePath, byte[] bytecode) throws IOException;
 
     protected abstract void visitResource(Path relativePath, byte[] bytecode) throws IOException;
 

--- a/src/main/java/org/javafxports/retrobuffer/Retrobuffer.java
+++ b/src/main/java/org/javafxports/retrobuffer/Retrobuffer.java
@@ -55,8 +55,12 @@ public class Retrobuffer {
         OutputDirectory outputDirectory = new OutputDirectory(outputDir);
         Files.walkFileTree(inputDir, new ClasspathVisitor() {
             @Override
-            protected void visitClass(byte[] bytecode) {
-                analyzer.analyze(bytecode);
+            protected void visitClass(Path relativePath, byte[] bytecode) {
+                try {
+                    analyzer.analyze(bytecode);
+                } catch (IllegalArgumentException e) {
+                    throw new RuntimeException("Failed to analyze class: '" + relativePath + "'.\nClasses compiled with JDK 9 or later are currently not supported on Android. Please make sure that your project does not contain JDK 9+ dependencies.", e);
+                }
             }
 
             @Override


### PR DESCRIPTION
RetroBuffer uses ASM to inspect classes. The supplied version only supports classes with bytecode version 52 or lower and throws an IllegalArgumentException when a class is detected with a higher bytecode version. This PR rethrows that exception with a message that is more meaningful for the developer.

Fixes #32 